### PR TITLE
Add Python3 requirements.txt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -368,8 +368,6 @@ To upgrade,
  
  * Makefile
  
- * Packaging for standalone execution outside AWS Lambda (`requirements.txt`, etc.), to encourage collaborative development
- 
  * Tags and reference dictionary updates to support scheduled restoration of images and snapshots
  
  * Generalization of reference dictionaries to support more AWS services and resource types. (Which ones?)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,40 @@
+# Suggested setup steps:
+#
+#   virtualenv --python=python3 VIRTUALENV_PATH
+#   source VIRTUALENV_PATH/bin/activate
+#   pip3 install --upgrade --requirement requirements.txt
+#
+# where VIRTUALENV_PATH is the path to your new Python 3 virtual environment
+
+
+# https://github.com/sqlxpert/aws-tag-sched-ops/
+#
+# Copyright 2017, Paul Marcelin
+#
+# This file is part of TagSchedOps.
+#
+# TagSchedOps is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# TagSchedOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with TagSchedOps. If not, see http://www.gnu.org/licenses/
+
+
+# Necessary for operation:
+boto3
+botocore
+
+# Useful for AWS administration:
+awscli
+
+# Necessary for development:
+pylint
+pycodestyle
+yamllint


### PR DESCRIPTION
Comment at start of `aws_tag_sched_ops.py` still holds true:
This code is meant for use as an AWS Lambda function,
and isn't documented for local execution.

Just writing down the following extra steps for local execution
makes me cringe about the security implications.
**Never do this in production!**

1. If running on an EC2 instance: Add an IAM role to the instance
   _OR_
   If running locally: provide IAM user's AWS API key ID and secret key:
   `aws configure`
2. Attach the two \*TagSchedOpsPerform\* policies to IAM role or IAM user
3. If running on an EC2 instance, set region, e.g.:
   `export AWS_DEFAULT_REGION='us-east-1'`