### PR TITLE
IAM policy: Admin - tighten/make consistent

### DIFF
--- a/cloudformation/aws_tag_sched_ops.yaml
+++ b/cloudformation/aws_tag_sched_ops.yaml
@@ -417,7 +417,7 @@ Resources:
     Type: "AWS::IAM::ManagedPolicy"
     DeletionPolicy: Delete
     Properties:
-      Description: "All EC2 instances, EBS volumes: describe; view tags; add, delete tags for scheduled operations. All EC2 images, EBS snapshots: describe; view tags; add, delete tags for deletion, but cannot delete images or snapshots. All CloudWatch events: describe. Event for TagSchedOps: enable and disable."
+      Description: "All EC2 instances, EBS volumes: describe; view tags; add, delete tags for scheduled operations. All EC2 images, EBS snapshots: describe; view tags; cannot delete images or snapshots, or tag for deletion. All CloudWatch events: describe. Event for TagSchedOps: enable and disable."
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -473,7 +473,9 @@ Resources:
                   # One-time schedule tags:
                   - "managed-snapshot-once"
 
-          - Effect: Allow
+          # Security: an entity that schedules backups cannot tag for deletion
+
+          - Effect: Deny
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
@@ -481,7 +483,7 @@ Resources:
               - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
               - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
             Condition:
-              "ForAllValues:StringEquals":
+              "ForAnyValue:StringEquals":
                 "aws:TagKeys":
                   - "managed-delete"
 
@@ -538,7 +540,7 @@ Resources:
     Type: "AWS::IAM::ManagedPolicy"
     DeletionPolicy: Delete
     Properties:
-      Description: "All RDS instances: describe; view tags; add, delete tags for scheduled operations. All RDS snapshots: describe; view tags; add, delete tags for deletion, but cannot delete snapshots.  All CloudWatch events: describe. Event for TagSchedOps: enable and disable. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
+      Description: "All RDS instances: describe; view tags; add, delete tags for scheduled operations. All RDS snapshots: describe; view tags; cannot delete snapshots, or tag for deletion.  All CloudWatch events: describe. Event for TagSchedOps: enable and disable. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -720,7 +722,10 @@ Resources:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-once": "*"
 
-          - Effect: Allow
+          # Security: An entity that can schedule backups
+          #           cannot delete them, or tag them for deletion.
+
+          - Effect: Deny
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
@@ -728,7 +733,7 @@ Resources:
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
-          - Effect: Deny  # Sec: an entity that tags for deletion cannot delete
+          - Effect: Deny
             Action: "rds:DeleteDBSnapshot"
             Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
 
@@ -1123,7 +1128,9 @@ Resources:
           #           cannot delete them, or tag them for deletion.
 
           - Effect: Deny
-            Action: "rds:AddTagsToResource"
+            Action:
+              - "rds:AddTagsToResource"
+              - "rds:RemoveTagsFromResource"
             Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
@@ -1447,7 +1454,9 @@ Resources:
           #           cannot delete them, or tag them for deletion.
 
           - Effect: Deny
-            Action: "rds:AddTagsToResource"
+            Action:
+              - "rds:AddTagsToResource"
+              - "rds:RemoveTagsFromResource"
             Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
@@ -1902,7 +1911,9 @@ Resources:
               - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
               - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
           - Effect: Deny  # ...and cannot tag for deletion
-            Action: "rds:AddTagsToResource"
+            Action:
+              - "rds:AddTagsToResource"
+              - "rds:RemoveTagsFromResource"
             Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:

--- a/readme.md
+++ b/readme.md
@@ -279,18 +279,17 @@ Resources tagged for unsupported combinations of operations are logged (with mes
    |Policy Name|Manage Enabling Tags|Manage One-Time Schedule Tags|Manage Repetitive Schedule Tags|Back Up|Manage Deletion Tag|Delete|
    |--|--|--|--|--|--|--|
    |_Scope &rarr;_|_Instances, Volumes_|_Instances, Volumes_|_Instances, Volumes_|_Instances, Volumes_|_Images, Snapshots_|_Images, Snapshots_|
-   |TagSchedOpsAdminister|Allow|Allow|Allow|No effect|Allow [<sup>i</sup>](#policy-footnote-1)|Deny|
-   |TagSchedOpsTagScheduleOnce|Deny [<sup>ii</sup>](#policy-footnote-2)|Allow [<sup>iii</sup>](#policy-footnote-3)|Deny|No effect|Deny|Deny|
-   |TagSchedOpsTagSchedulePeriodic|Deny [<sup>ii</sup>](#policy-footnote-2)|No effect|Allow [<sup>iii</sup>](#policy-footnote-3)|No Effect|Deny|Deny|
+   |TagSchedOpsAdminister|Allow|Allow|Allow|No effect|Deny|Deny|
+   |TagSchedOpsTagScheduleOnce|Deny [<sup>i</sup>](#policy-footnote-1)|Allow [<sup>ii</sup>](#policy-footnote-2)|Deny|No effect|Deny|Deny|
+   |TagSchedOpsTagSchedulePeriodic|Deny [<sup>i</sup>](#policy-footnote-1)|No effect|Allow [<sup>ii</sup>](#policy-footnote-2)|No Effect|Deny|Deny|
    |TagSchedOpsTagForDeletion|Deny|Deny|Deny|Deny|Allow|Deny|
    |TagSchedOpsDelete|Deny|Deny|Deny|Deny|Deny|Allow|
    |TagSchedOpsNoTag|Deny|Deny|Deny|No effect|Deny|Deny|
    
    Footnotes:
    
-     1. <a name="policy-footnote-1"></a>This convenience makes the policy suitable only for highly-trusted users. Never use this policy for any kind of automation.
-     2. <a name="policy-footnote-2"></a>For RDS, No Effect.
-     2. <a name="policy-footnote-3"></a>Enabling tag required. For example, a user could only add `managed-image-once` to an EC2 instance already tagged with `managed-image`.
+     1. <a name="policy-footnote-1"></a>For RDS, No Effect.
+     2. <a name="policy-footnote-2"></a>Enabling tag required. For example, a user could only add `managed-image-once` to an EC2 instance already tagged with `managed-image`.
       
    Because Deny always takes precendence in IAM, some policy combinations conflict.
    


### PR DESCRIPTION
Enforcing a consistent separation between the right to schedule backups and the
right to tag backups for deletion, because there is nothing I can do to prevent
inadvertent use of the *Administer policies for automations (which could be
hacked to take advantage of the prior exception), or to untrustworthy
individuals (who, short of deleting all backups, could simply tag them and let
some future automation delete them all). Too risky!