### PR TITLE
Multi-region + CloudFormation StackSets

### DIFF
--- a/cloudformation/aws_tag_sched_ops.yaml
+++ b/cloudformation/aws_tag_sched_ops.yaml
@@ -31,20 +31,32 @@ Description: "Start, reboot, stop and back up AWS resources using tag-based sche
 
 Parameters:
 
+  StackSetsOrMultiRegion:
+    Type: String
+    Description: "Whether you are creating this stack in multiple regions, and/or are using the StackSets feature of CloudFormation"
+    AllowedValues:
+      - "No"
+      - "Yes"
+    Default: "No"
   LambdaCodeS3Bucket:
     Type: String
-    Description: "Name (with no prefix of any kind) of the S3 bucket where AWS Lambda function source code is stored. Carefully restrict write (PutObject) access."
+    Description: "Name of the S3 bucket where AWS Lambda function source code is stored. (For multi-region or CloudFormation StackSets scenarios, an S3 bucket with this name PLUS a region suffix, e.g., my-bucket-us-east-1, must exist in EACH target region, and must contain the SAME source code file, readable by EVERY target AWS account.)"
   TagSchedOpsPerformCodeName:
     Type: String
     Description: "Name (without the .py.zip suffix) of the file (S3 object) containing compressed source code for the TagSchedOpsPerform AWS Lamba function. Accept the default unless directed otherwise."
     Default: "aws_tag_sched_ops_perform"
-  TagSchedOpsPerformCodeVersion:
+  TagSchedOpsPerformCodeS3VersionID:
     Type: String
-    Description: "Version ID for the desired version of the TagSchedOpsPerform source code S3 object. Leave blank, unless object versioning has been turned on for the S3 bucket."
+    Description: "Version ID for the desired version of the TagSchedOpsPerform source code S3 object. Leave blank, unless object versioning has been turned on for the S3 bucket. (If using CloudFormation StackSets, always leave blank.)"
     Default: ""
 
-  # Do not validate at CloudFormation level, in case underlying APIs change:
+  # Do not validate at CloudFormation level,
+  # in case values accepted by underlying APIs change:
 
+  MainRegion:
+    Type: String  # No AWS-specific parameter type for this!
+    Description: "The first region where the TagSchedOps stack was created, is being created, or will be created. (This is compared with the current region, to prevent the creation of multiple sets of identical IAM policies. For CloudFormation StackSets, include this region on the list of regions for EVERY target account.)"
+    Default: "us-east-1"
   TagSchedOpsPerformLogRetainDays:
     Type: Number
     Description: "How many days to keep logs from the TagSchedOpsPerform AWS Lambda function. Typical values are 1, 7, 14, 30, 60, and 90 days, but for the full list, see http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html"
@@ -60,7 +72,11 @@ Parameters:
 
 Conditions:
   TagSchedOpsPerformCodeNoS3ObjVersion:
-    !Equals [ !Ref TagSchedOpsPerformCodeVersion, "" ]
+    !Equals [ !Ref TagSchedOpsPerformCodeS3VersionID, "" ]
+  RegionMulti:
+    !Equals [ !Ref StackSetsOrMultiRegion, "Yes" ]
+  UserIamPoliciesCreate:
+    !Equals [ !Ref MainRegion, !Ref "AWS::Region" ]
 
 Resources:
 
@@ -249,13 +265,13 @@ Resources:
     # Not a strict dependency, from CloudFormation's perspective.
     # This policy need not have been created and attached before the
     # AWS Lambda function is created, but rather, before it first runs:
-    # DependsOn: SchedOpsPerformPol
+    # DependsOn: TagSchedOpsPerformLog
     DeletionPolicy: Delete
     Properties:
       Code:
-        S3Bucket: !Ref LambdaCodeS3Bucket
+        S3Bucket: !If [ RegionMulti, !Sub "${LambdaCodeS3Bucket}-${AWS::Region}", !Ref LambdaCodeS3Bucket ]
         S3Key: !Join [ ".", [ !Ref TagSchedOpsPerformCodeName, "py", "zip" ] ]
-        S3ObjectVersion: !If [ TagSchedOpsPerformCodeNoS3ObjVersion, !Ref "AWS::NoValue", !Ref TagSchedOpsPerformCodeVersion ]
+        S3ObjectVersion: !If [ TagSchedOpsPerformCodeNoS3ObjVersion, !Ref "AWS::NoValue", !Ref TagSchedOpsPerformCodeS3VersionID ]
       Handler: !Join [ ".", [ !Ref TagSchedOpsPerformCodeName, "lambda_handler" ] ]
       MemorySize: !Ref TagSchedOpsPerformMemoryMB
       Role: !GetAtt TagSchedOpsPerformLambdaRole.Arn
@@ -274,7 +290,7 @@ Resources:
       RetentionInDays: !Ref TagSchedOpsPerformLogRetainDays
 
 
-  SchedOpsPerformPol:
+  TagSchedOpsPerformLog:
     Type: "AWS::IAM::ManagedPolicy"
     DeletionPolicy: Delete
     Properties:
@@ -338,6 +354,7 @@ Resources:
 
   TagSchedOpsPerformLambdaFnProtect:  # Name in ARN on final line must match!
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "TagSchedOpsPerform Lambda function, CloudWatch log group, log stream, and CloudWatch event: cannot change or delete. TagSchedOpsPerform Lambda function: cannot invoke manually. This policy may not be exhaustive."
@@ -352,6 +369,7 @@ Resources:
               - "lambda:PublishVersion"
               - "lambda:UpdateFunctionConfiguration"
               - "lambda:AddPermission"
+              - "lambda:RemovePermission"
               - "lambda:InvokeFunction"
             Resource: !GetAtt TagSchedOpsPerformLambdaFn.Arn
 
@@ -375,7 +393,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           - Effect: Deny
             Action:
@@ -404,7 +422,7 @@ Resources:
               - "iam:CreatePolicyVersion"
               - "iam:DeletePolicyVersion"
             Resource:
-              - !Ref SchedOpsPerformPol
+              - !Ref TagSchedOpsPerformLog
               - !Ref Ec2TagSchedOpsPerform
               - !Ref RdsTagSchedOpsPerform
               # !Ref TagSchedOpsPerformLambdaFnProtect
@@ -415,6 +433,7 @@ Resources:
 
   Ec2TagSchedOpsAdminister:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All EC2 instances, EBS volumes: describe; view tags; add, delete tags for scheduled operations. All EC2 images, EBS snapshots: describe; view tags; cannot delete images or snapshots, or tag for deletion. All CloudWatch events: describe. Event for TagSchedOps: enable and disable."
@@ -435,7 +454,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAllValues:StringEquals":
                 "aws:TagKeys":
@@ -462,7 +481,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAllValues:StringEquals":
                 "aws:TagKeys":
@@ -480,8 +499,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -511,7 +530,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -538,6 +557,7 @@ Resources:
 
   RdsTagSchedOpsAdminister:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All RDS instances: describe; view tags; add, delete tags for scheduled operations. All RDS snapshots: describe; view tags; cannot delete snapshots, or tag for deletion.  All CloudWatch events: describe. Event for TagSchedOps: enable and disable. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
@@ -553,8 +573,8 @@ Resources:
           - Effect: Allow
             Action: "rds:ListTagsForResource"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           # The "rds:req-tag/..." Condition key supported by RDS is equivalent
           # to the "aws:RequestTag/..." Condition key supported by EC2. These
@@ -579,7 +599,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start": "*"
@@ -587,7 +607,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot": "*"
@@ -595,7 +615,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover": "*"
@@ -603,7 +623,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop": "*"
@@ -611,7 +631,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot": "*"
@@ -619,7 +639,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop": "*"
@@ -628,7 +648,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-periodic": "*"
@@ -636,7 +656,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-periodic": "*"
@@ -644,7 +664,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-periodic": "*"
@@ -652,7 +672,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-periodic": "*"
@@ -660,7 +680,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-periodic": "*"
@@ -668,7 +688,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-periodic": "*"
@@ -677,7 +697,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-once": "*"
@@ -685,7 +705,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-once": "*"
@@ -693,7 +713,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-once": "*"
@@ -701,7 +721,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-once": "*"
@@ -709,7 +729,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-once": "*"
@@ -717,7 +737,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-once": "*"
@@ -729,13 +749,13 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
           - Effect: Deny
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           # See effects of tags
 
@@ -752,7 +772,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -779,6 +799,7 @@ Resources:
 
   Ec2TagSchedOpsScheduleOnce:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "EC2 instances, EBS volumes tagged to enable a managed operation: add, delete one-time schedule tags for that operation. All EC2 instances, EBS volumes: describe; view tags; cannot add or delete operation-enabling or repetitive schedule tags. All EC2 images, EBS snapshots: describe; view tags; cannot delete, or tag for deletion."
@@ -799,7 +820,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-start": "*"
@@ -810,7 +831,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-reboot": "*"
@@ -821,7 +842,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-reboot-image": "*"
@@ -832,7 +853,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-image": "*"
@@ -843,7 +864,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-stop": "*"
@@ -855,7 +876,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-snapshot": "*"
@@ -869,7 +890,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -889,7 +910,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -914,8 +935,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -936,7 +957,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -947,6 +968,7 @@ Resources:
 
   RdsTagSchedOpsScheduleOnce:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "RDS instances tagged to enable a managed operation: add, delete one-time schedule tags for that operation. All RDS instances: describe; view tags; cannot add or delete operation-enabling or repetitive schedule tags. All RDS snapshots: describe; view tags; cannot delete, or tag for deletion. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
@@ -962,14 +984,14 @@ Resources:
           - Effect: Allow
             Action: "rds:ListTagsForResource"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           - Effect: Allow
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-start": "*"
@@ -978,7 +1000,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-reboot": "*"
@@ -987,7 +1009,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-reboot-failover": "*"
@@ -996,7 +1018,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-stop": "*"
@@ -1005,7 +1027,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-snapshot": "*"
@@ -1014,7 +1036,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-snapshot-stop": "*"
@@ -1028,7 +1050,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-start": "*"
@@ -1036,7 +1058,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-reboot": "*"
@@ -1044,7 +1066,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-reboot-failover": "*"
@@ -1052,7 +1074,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-stop": "*"
@@ -1060,7 +1082,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-snapshot": "*"
@@ -1068,7 +1090,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-snapshot-stop": "*"
@@ -1079,7 +1101,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-periodic": "*"
@@ -1087,7 +1109,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-periodic": "*"
@@ -1095,7 +1117,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-periodic": "*"
@@ -1103,7 +1125,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-periodic": "*"
@@ -1111,7 +1133,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-periodic": "*"
@@ -1119,7 +1141,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-periodic": "*"
@@ -1131,13 +1153,13 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
           - Effect: Deny
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           # See effects of tags
 
@@ -1154,7 +1176,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -1165,6 +1187,7 @@ Resources:
 
   Ec2TagSchedOpsSchedulePeriodic:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "EC2 instances, EBS volumes tagged to enable a managed operation: add, delete repetitive schedule tags for that operation. All EC2 instances, EBS volumes: describe; view tags; cannot add or delete operation-enabling tags. All EC2 images, EBS snapshots: describe; view tags; cannot delete, or tag for deletion."
@@ -1185,7 +1208,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-start": "*"
@@ -1196,7 +1219,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-reboot": "*"
@@ -1207,7 +1230,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-reboot-image": "*"
@@ -1218,7 +1241,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-image": "*"
@@ -1229,7 +1252,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-stop": "*"
@@ -1241,7 +1264,7 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
 
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               StringLike:
                 "ec2:ResourceTag/managed-snapshot": "*"
@@ -1255,7 +1278,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1269,7 +1292,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1291,8 +1314,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1313,7 +1336,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -1324,6 +1347,7 @@ Resources:
 
   RdsTagSchedOpsSchedulePeriodic:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "RDS instances tagged to enable a managed operation: add, delete repetitive schedule tags for that operation. All RDS instances: describe; view tags; cannot add or delete operation-enabling tags. All RDS snapshots: describe; view tags; cannot delete, or tag for deletion. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
@@ -1339,14 +1363,14 @@ Resources:
           - Effect: Allow
             Action: "rds:ListTagsForResource"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           - Effect: Allow
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-start": "*"
@@ -1355,7 +1379,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-reboot": "*"
@@ -1364,7 +1388,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-reboot-failover": "*"
@@ -1373,7 +1397,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-stop": "*"
@@ -1382,7 +1406,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-snapshot": "*"
@@ -1391,7 +1415,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:db-tag/managed-snapshot-stop": "*"
@@ -1405,7 +1429,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-start": "*"
@@ -1413,7 +1437,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-reboot": "*"
@@ -1421,7 +1445,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-reboot-failover": "*"
@@ -1429,7 +1453,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-stop": "*"
@@ -1437,7 +1461,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-snapshot": "*"
@@ -1445,7 +1469,7 @@ Resources:
           #   Action:
           #     - "rds:AddTagsToResource"
           #     - "rds:RemoveTagsFromResource"
-          #   Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+          #   Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
           #   Condition:
           #     StringLike:
           #       "rds:req-tag/managed-snapshot-stop": "*"
@@ -1457,13 +1481,13 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
           - Effect: Deny
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           # See effects of tags
 
@@ -1480,7 +1504,7 @@ Resources:
             # ARN is the log group's name, which in this case is
             # the final name of the AWS Lambda function, including
             # the random string appended by CloudFormation:
-            Resource: !Join [ ":", [ !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
+            Resource: !Join [ ":", [ !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group", !Select [ 6, !Split [ ":", !GetAtt TagSchedOpsPerformLogGrp.Arn ] ], "log-stream", "*" ] ]
 
           # Diagnose permissions errors
 
@@ -1491,6 +1515,7 @@ Resources:
 
   Ec2TagSchedOpsTagForDeletion:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All EC2 images, EBS snapshots: describe; view tags; add, delete tags for deletion, but cannot delete images or snapshots. All EC2 instances, EBS volumes: describe; view tags; cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags."
@@ -1512,8 +1537,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAllValues:StringEquals":
                 "aws:TagKeys":
@@ -1543,7 +1568,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1570,7 +1595,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1590,6 +1615,7 @@ Resources:
 
   RdsTagSchedOpsTagForDeletion:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All RDS snapshots: describe; view tags; add, delete tags for deletion, but cannot delete snapshots. All RDS instances: describe; view tags; cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags. Due to an AWS limitation, ANY tag can be added with an intended tag. Withholding all RDS tagging privileges is safer than relying on this policy."
@@ -1605,30 +1631,30 @@ Resources:
           - Effect: Allow
             Action: "rds:ListTagsForResource"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           - Effect: Allow  # Security: an entity that tags for deletion...
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
           - Effect: Deny  # Security: ...cannot create...
             Action: "rds:CreateDBSnapshot"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
           - Effect: Deny  # [another way to create RDS snapshots]
             Action: "rds:StopDBInstance"  # With snapshot option
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
           - Effect: Deny  # Security: ...and cannot delete.
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
 
           # Deny addition/modification/deletion of operation-enabling tags
 
@@ -1636,7 +1662,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start": "*"
@@ -1644,7 +1670,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot": "*"
@@ -1652,7 +1678,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover": "*"
@@ -1660,7 +1686,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop": "*"
@@ -1668,7 +1694,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot": "*"
@@ -1676,7 +1702,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop": "*"
@@ -1687,7 +1713,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-once": "*"
@@ -1695,7 +1721,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-once": "*"
@@ -1703,7 +1729,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-once": "*"
@@ -1711,7 +1737,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-once": "*"
@@ -1719,7 +1745,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-once": "*"
@@ -1727,7 +1753,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-once": "*"
@@ -1738,7 +1764,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-periodic": "*"
@@ -1746,7 +1772,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-periodic": "*"
@@ -1754,7 +1780,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-periodic": "*"
@@ -1762,7 +1788,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-periodic": "*"
@@ -1770,7 +1796,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-periodic": "*"
@@ -1778,7 +1804,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-periodic": "*"
@@ -1790,8 +1816,9 @@ Resources:
             Resource: "*"
 
 
-  Ec2TagSchedOpsDelete:
+  Ec2TagSchedOpsBackupDelete:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All EC2 images, EBS snapshots: delete, but cannot tag for deletion, or create. All EC2 instances, EBS volumes: cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags."
@@ -1828,8 +1855,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1839,7 +1866,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1866,7 +1893,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -1878,8 +1905,9 @@ Resources:
                   - "managed-snapshot-once"
 
 
-  RdsTagSchedOpsDelete:
+  RdsTagSchedOpsBackupDelete:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "RDS snapshots tagged for deletion: delete. All RDS snapshots: cannot tag for deletion, or create. All RDS instances: cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags."
@@ -1892,10 +1920,10 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action: "rds:ListTagsForResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
           - Effect: Allow
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:snapshot-tag/managed-delete": "*"
@@ -1903,18 +1931,18 @@ Resources:
           - Effect: Deny  # Security: an entity that deletes cannot create...
             Action: "rds:CreateDBSnapshot"
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
           - Effect: Deny  # [another way to create RDS snapshots]
             Action: "rds:StopDBInstance"  # With snapshot option
             Resource:
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
+              - !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
           - Effect: Deny  # ...and cannot tag for deletion
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
@@ -1925,7 +1953,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start": "*"
@@ -1933,7 +1961,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot": "*"
@@ -1941,7 +1969,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover": "*"
@@ -1949,7 +1977,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop": "*"
@@ -1957,7 +1985,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot": "*"
@@ -1965,7 +1993,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop": "*"
@@ -1976,7 +2004,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-once": "*"
@@ -1984,7 +2012,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-once": "*"
@@ -1992,7 +2020,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-once": "*"
@@ -2000,7 +2028,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-once": "*"
@@ -2008,7 +2036,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-once": "*"
@@ -2016,7 +2044,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-once": "*"
@@ -2027,7 +2055,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-periodic": "*"
@@ -2035,7 +2063,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-periodic": "*"
@@ -2043,7 +2071,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-periodic": "*"
@@ -2051,7 +2079,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-periodic": "*"
@@ -2059,7 +2087,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-periodic": "*"
@@ -2067,7 +2095,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-periodic": "*"
@@ -2075,6 +2103,7 @@ Resources:
 
   Ec2TagSchedOpsNoTag:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All EC2 instances, EBS volumes: cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags. All EC2 images, EBS snapshots: cannot tag for deletion, and cannot delete."
@@ -2086,7 +2115,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:instance/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -2113,7 +2142,7 @@ Resources:
             Action:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*"
+            Resource: !Sub "arn:aws:ec2:*:${AWS::AccountId}:volume/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -2131,8 +2160,8 @@ Resources:
               - "ec2:CreateTags"
               - "ec2:DeleteTags"
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}::image/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}::snapshot/*"
+              - !Sub "arn:aws:ec2:*::image/*"
+              - !Sub "arn:aws:ec2:*::snapshot/*"
             Condition:
               "ForAnyValue:StringEquals":
                 "aws:TagKeys":
@@ -2150,6 +2179,7 @@ Resources:
 
   RdsTagSchedOpsNoTag:
     Type: "AWS::IAM::ManagedPolicy"
+    Condition: UserIamPoliciesCreate
     DeletionPolicy: Delete
     Properties:
       Description: "All RDS instances: cannot add or delete operational-enabling, one-time schedule, or repetitive schedule tags. All RDS snapshots: cannot tag for deletion, and cannot delete."
@@ -2163,7 +2193,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start": "*"
@@ -2171,7 +2201,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot": "*"
@@ -2179,7 +2209,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover": "*"
@@ -2187,7 +2217,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop": "*"
@@ -2195,7 +2225,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot": "*"
@@ -2203,7 +2233,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop": "*"
@@ -2214,7 +2244,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-once": "*"
@@ -2222,7 +2252,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-once": "*"
@@ -2230,7 +2260,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-failover-once": "*"
@@ -2238,7 +2268,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-once": "*"
@@ -2246,7 +2276,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-once": "*"
@@ -2254,7 +2284,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-once": "*"
@@ -2265,7 +2295,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-start-periodic": "*"
@@ -2273,7 +2303,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-reboot-periodic": "*"
@@ -2281,7 +2311,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-stop-periodic": "*"
@@ -2289,7 +2319,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-periodic": "*"
@@ -2297,7 +2327,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:db:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-snapshot-stop-periodic": "*"
@@ -2308,7 +2338,7 @@ Resources:
             Action:
               - "rds:AddTagsToResource"
               - "rds:RemoveTagsFromResource"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"
             Condition:
               StringLike:
                 "rds:req-tag/managed-delete": "*"
@@ -2317,4 +2347,4 @@ Resources:
 
           - Effect: Deny
             Action: "rds:DeleteDBSnapshot"
-            Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:*"
+            Resource: !Sub "arn:aws:rds:*:${AWS::AccountId}:snapshot:*"

--- a/cloudformation/aws_tag_sched_ops_pre_install.yaml
+++ b/cloudformation/aws_tag_sched_ops_pre_install.yaml
@@ -1,0 +1,300 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: "Prerequisite for installing TagSchedOps using CloudFormation with an assumed role, or CloudFormation StackSets. Copyright 2017, Paul Marcelin. https://github.com/sqlxpert/aws-tag-sched-ops/"
+
+
+# To check YAML syntax, first complete the setup steps
+# in aws-tag-sched-ops/requirements.txt and then run:
+#   yamllint -c aws-tag-sched-ops/.yamllint aws-tag-sched-ops/cloudformation/aws_tag_sched_ops.yaml
+
+
+# https://github.com/sqlxpert/aws-tag-sched-ops/
+#
+# Copyright 2017, Paul Marcelin
+#
+# This file is part of TagSchedOps.
+#
+# TagSchedOps is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# TagSchedOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with TagSchedOps. If not, see http://www.gnu.org/licenses/
+
+
+Parameters:
+  AdministratorAccountId:
+    Type: String
+    Description: "AWS account number for StackSets administration account (where parent StackSets will be created). Does not change the AWS account in AWSCloudFormationStackSetExecutionRoleStatus, if that role already exists."
+    MaxLength: 12
+    MinLength: 12
+  AWSCloudFormationStackSetExecutionRoleStatus:
+    Type: String
+    Description: "Status of the service role for CloudFormation StackSets, AWSCloudFormationStackSetExecutionRole, in current account (a StackSets target account, where child CloudFormation stacks will be created)"
+    AllowedValues:
+      - "Role does not exist"
+      - "Role exists, AdministratorAccess policy attached"
+      - "Role exists, CloudFormationFullAccess and StackSetExecutionMisc attached"
+      - "Role exists, policies above not attached"
+      # In the rare case where the CloudFormationFullAccess and
+      # CloudFormationStackSetExecutionMisc IAM policies exist (from a prior
+      # installation) but are no longer attached to the role, the user should
+      # re-attach them, or simply delete them, before answering this question.
+      # Custom name-related limitations prevent using a CloudFormation
+      # template to attach the pre-existing policies to the pre-existing role.
+    Default: "Role does not exist"
+  LambdaCodeS3Bucket:
+    Type: String
+    Description: "Name (with no prefix of any kind) of the S3 bucket where AWS Lambda function source code is stored"
+  TagSchedOpsCloudFormationStackNamePrefix:
+    Type: String
+    Description: "First part of the name of TagSchedOps CloudFormation stacks. (If you plan to create the TagSchedOps stack in one or more regions, using CloudFormation with an assumed role, and without StackSets, the name of each such stack must start with the prefix that you specify here.)"
+    Default: "TagSchedOps"
+
+Conditions:
+  AWSCloudFormationStackSetExecutionRoleCreate:
+    !Equals [ !Ref AWSCloudFormationStackSetExecutionRoleStatus, "Role does not exist" ]
+  CloudFormationStackSetExecutionPoliciesCreateAttach:
+    # Custom, least-privilege alternative to AdministratorAccess
+    !Equals [ !Ref AWSCloudFormationStackSetExecutionRoleStatus, "Role exists, policies above not attached" ]
+  AdministratorAndTargetSameAccount:
+    !Equals [ !Ref AdministratorAccountId, !Ref "AWS::AccountId" ]
+
+Resources:
+
+
+  AWSCloudFormationStackSetExecutionRole:
+    # Replaces Step 2 in
+    # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html#stacksets-prereqs-accountsetup
+    # Adapted from
+    # https://s3.amazonaws.com/cloudformation-stackset-sample-templates-us-east-1/AWSCloudFormationStackSetExecutionRole.yml
+    Type: AWS::IAM::Role
+    Condition: AWSCloudFormationStackSetExecutionRoleCreate
+    DeletionPolicy: Retain  # For any StackSets other than TagSchedOps
+    Properties:
+      Path: "/"
+      RoleName: "AWSCloudFormationStackSetExecutionRole"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: { "AWS": !Ref AdministratorAccountId }
+            Action: "sts:AssumeRole"
+
+
+  TagSchedOpsCloudFormation:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Delete
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: { "Service": "cloudformation.amazonaws.com" }
+            Action: "sts:AssumeRole"
+
+
+  CloudFormationFullAccess:
+    Type: "AWS::IAM::ManagedPolicy"
+    Condition: CloudFormationStackSetExecutionPoliciesCreateAttach
+    DeletionPolicy: Retain  # For any StackSets other than TagSchedOps
+    Properties:
+      ManagedPolicyName: "CloudFormationFullAccess"
+      Description: "CloudFormation: perform any action. (Needed for the CloudFormation StackSets service role in target accounts; not currently offered as an AWS-managed policy.)"
+      Roles:
+        # If role is being created by this template: CloudFormation dependency
+        # If role already exists: no dependency (prevents an error)
+        - !If [ AWSCloudFormationStackSetExecutionRoleCreate, !Ref AWSCloudFormationStackSetExecutionRole, "AWSCloudFormationStackSetExecutionRole" ]
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: "cloudformation:*"
+            Resource: "*"
+
+
+  CloudFormationStackSetExecutionMisc:
+    Type: "AWS::IAM::ManagedPolicy"
+    Condition: CloudFormationStackSetExecutionPoliciesCreateAttach
+    DeletionPolicy: Retain  # For any StackSets other than TagSchedOps
+    Properties:
+      ManagedPolicyName: "CloudFormationStackSetExecutionMisc"
+      Description: "S3: read from executor-templates-* buckets. SNS: publish to StackSet-* topics. (Needed for the CloudFormation StackSets service role in target accounts.)"
+      Roles:
+        # If role is being created by this template: CloudFormation dependency
+        # If role already exists: no dependency (prevents an error)
+        - !If [ AWSCloudFormationStackSetExecutionRoleCreate, !Ref AWSCloudFormationStackSetExecutionRole, "AWSCloudFormationStackSetExecutionRole" ]
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "sns:Publish"
+            # Requirement discovered through StackSets Console error:
+            #   User: arn:aws:sts::ACCOUNT1:assumed-role/
+            #   AWSCloudFormationStackSetExecutionRole/UUID1 is
+            #   not authorized to perform: SNS:Publish on resource:
+            #   arn:aws:sns:REGION:ACCOUNT2:StackSet-UUID2
+            Resource: !Sub "arn:aws:sns:*:*:StackSet-*"
+          - Effect: Allow
+            Action:
+              - "s3:GetObject*"
+            # Requirement discovered through StackSets Console error:
+            #   TemplateURL must reference a valid
+            #   S3 object to which you have access.
+            # Bucket name discovered through CloudTrail trail:
+            #   Trail settings: Apply trail to all regions
+            #   Data events: Select all S3 buckets in your account, Read
+            Resource: "arn:aws:s3:::executor-templates-*/*"
+
+
+  TagSchedOpsInstall:
+    Type: "AWS::IAM::ManagedPolicy"
+    DeletionPolicy: Delete
+    Properties:
+      Description: "TagSchedOps: create, update, delete CloudFormation stack."
+      Roles:
+        - !Ref TagSchedOpsCloudFormation
+
+        # If role is being created by this template: CloudFormation dependency
+        # If role already exists: no dependency (prevents an error)
+        - !If [ AWSCloudFormationStackSetExecutionRoleCreate, !Ref AWSCloudFormationStackSetExecutionRole, "AWSCloudFormationStackSetExecutionRole" ]
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+
+          - Effect: Allow
+            Action:
+              - "s3:GetObject"
+              - "s3:GetObjectVersion"
+            # Sufficient only for the most basic scenario: single-account,
+            # multi-region. For a multi-account scenario, the user should
+            # instead attach a bucket policy to the bucket for each region,
+            # allowing access by all StackSets taget accounts. Use of
+            # S3 ACLs, let alone public read access, is discouraged.
+            # (CloudFormation allows the Condition key in resource blocks,
+            # but not inside property, like this IAM policy statement.
+            # Work-around: conditionally set Resource to a nonsense ARN.)
+            Resource: !If [ AdministratorAndTargetSameAccount, !Sub "arn:aws:s3:::${LambdaCodeS3Bucket}-*/*", "arn:aws:s3:::NO-SUCH-BUCKET" ]
+
+          - Effect: Allow
+            Action:
+              - "lambda:CreateFunction"
+              - "lambda:GetFunction"
+              - "lambda:DeleteFunction"
+              - "lambda:UpdateFunctionCode"
+              - "lambda:GetFunctionConfiguration"
+              - "lambda:UpdateFunctionConfiguration"
+              - "lambda:AddPermission"
+              - "lambda:RemovePermission"
+            Resource:
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action:
+              - "lambda:CreateEventSourceMapping"
+              - "lambda:UpdateEventSourceMapping"
+              - "lambda:DeleteEventSourceMapping"
+            Resource: "*"
+            Condition:
+              StringLike:
+                "lambda:FunctionArn":
+                  # CloudFormation StackSets installation:
+                  - !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:StackSet-*TagSchedOps*"
+                  # CloudFormation installation (assumed role, no StackSets):
+                  - !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action:
+              - "logs:CreateLogGroup"
+              - "logs:PutRetentionPolicy"
+              - "logs:DeleteRetentionPolicy"
+            Resource:
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action:
+              - "logs:DescribeLogGroups"
+            Resource: "*"
+
+          - Effect: Allow
+            Action:
+              - "events:PutRule"
+              - "events:DescribeRule"
+              - "events:EnableRule"
+              - "events:DisableRule"
+              - "events:DeleteRule"
+              - "events:PutTargets"
+              - "events:ListTargetsByRule"
+              - "events:RemoveTargets"
+            Resource:
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:events:*:${AWS::AccountId}:rule/StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:events:*:${AWS::AccountId}:rule/${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action: "iam:PassRole"
+            Resource:
+              # ARNs below MUST agree with role's CloudFormation
+              # logical name in cloudformation/aws_tag_sched_ops.yaml
+              # (NB: StackSets seems to truncate role names)
+
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${TagSchedOpsCloudFormationStackNamePrefix}*-TagSchedOpsPerformLambdaRole-*"
+
+          - Effect: Allow
+            Action:
+              - "iam:CreatePolicy"
+              - "iam:GetPolicy"
+              - "iam:DeletePolicy"
+              - "iam:CreatePolicyVersion"
+              - "iam:ListPolicyVersions"
+              - "iam:GetPolicyVersion"
+              - "iam:DeletePolicyVersion"
+            Resource:
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:policy/StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action:
+              - "iam:CreateRole"
+              - "iam:GetRole"
+              - "iam:DeleteRole"
+              - "iam:UpdateAssumeRolePolicy"
+              - "iam:ListRolePolicies"
+              - "iam:GetRolePolicy"
+              - "iam:AttachRolePolicy"
+              - "iam:DetachRolePolicy"
+              - "iam:ListEntitiesForPolicy"
+              # - "iam:PutRolePolicy"
+              # - "iam:DeleteRolePolicy"
+            Resource:
+              # CloudFormation StackSets installation:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/StackSet-*TagSchedOps*"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:policy/StackSet-*TagSchedOps*"
+              # CloudFormation installation (assumed role, no StackSets):
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${TagSchedOpsCloudFormationStackNamePrefix}*"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:policy/${TagSchedOpsCloudFormationStackNamePrefix}*"
+
+          - Effect: Allow
+            Action:
+              - "iam:ListAttachedRolePolicies"
+            Resource: "*"


### PR DESCRIPTION
* Addresses sqlxpert/aws-tag-sched-ops#10

    * Current region (`${AWS::Region}`) removed from user IAM policies.
    * Main region concept added. To prevent duplicates, user policies
      will not be created outside the main region.
    * Pre-installation template creates a CloudFormation service role
      and attaches a least-privilege policy, to avoid the need for
      AdministratorAccess when installing or updating TagSchedOps.
    * Same template creates a CloudFormation StackSets service role for
      target accounts. Attaches general-purpose StackSets policies, as well
      as the least-privilege policy for installing and updating TagSchedOps.
      StackSets administration account and target account may be the same,
      allowing for easy multi-region installation.
    * CloudFormation with an assumed role, and CloudFormation StackSets,
      are completely optional.

* Advanced installation documentation to follow